### PR TITLE
Loadouts and jobs/bl_job_information.dm Integration

### DIFF
--- a/_maps/map_files/Brattleboro/brattleboro-Upper.dmm
+++ b/_maps/map_files/Brattleboro/brattleboro-Upper.dmm
@@ -2200,6 +2200,7 @@
 /obj/machinery/msgterminal{
 	dir = 4
 	},
+/obj/structure/table,
 /turf/open/floor/wood/wood_wide,
 /area/f13/building)
 "kp" = (

--- a/_maps/map_files/debug/debug.dmm
+++ b/_maps/map_files/debug/debug.dmm
@@ -1,264 +1,272 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /obj/effect/landmark/start/f13/dfs_advisor,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "aB" = (
 /obj/machinery/light/floor,
 /turf/open/indestructible/ground/bl/outside/grass_standard/meadow,
 /area/f13/wasteland)
 "aL" = (
 /obj/machinery/autolathe/ammo/army,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "bj" = (
 /obj/item/gun/ballistic/fatman,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "bR" = (
 /obj/item/ammo_casing/caseless/fatman,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "cB" = (
 /obj/machinery/autolathe/secure,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "cL" = (
 /obj/machinery/autolathe,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "ds" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 4
 	},
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "dJ" = (
 /turf/open/indestructible/ground/bl/outside/grass_standard/meadow,
 /area/f13/wasteland)
 "es" = (
 /obj/effect/landmark/start/f13/gmb_commander,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "ew" = (
 /obj/effect/landmark/start/f13/hilltop_settler,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "eF" = (
 /obj/machinery/autolathe/constructionlathe,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "eO" = (
 /obj/item/seeds/bl/milkweed,
 /turf/open/indestructible/ground/bl/mud,
-/area/f13/wasteland)
+/area/f13/admeme)
 "fH" = (
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "fN" = (
 /obj/item/seeds/bl/licorice,
 /turf/open/indestructible/ground/bl/mud,
-/area/f13/wasteland)
+/area/f13/admeme)
 "gI" = (
 /obj/effect/landmark/start/f13/vaultengineer,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "gM" = (
 /obj/structure/shieldwall/large/active,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "gX" = (
 /obj/structure/billboard/vb/gmtammo,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "hd" = (
 /obj/structure/shieldwall/standard/lethal,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "iI" = (
 /turf/open/liquid/water,
-/area/f13/wasteland)
+/area/f13/wasteland/bl/lbj)
 "iS" = (
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "ju" = (
 /obj/machinery/autolathe/ammo/unlocked,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "la" = (
 /obj/effect/landmark/start/f13/secchief,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "nw" = (
 /obj/structure/billboard/vb/glazedholes,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "qA" = (
 /obj/effect/landmark/start/f13/gmb_volunteer,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
+"rk" = (
+/obj/item/gun/magic/wand/death/debug,
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "rH" = (
 /obj/machinery/manned_turret/m2,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "rR" = (
 /turf/open/liquid/water/deep,
-/area/f13/village)
+/area/f13/wasteland/bl/lbj)
 "sd" = (
 /obj/effect/landmark/start/f13/dfs_regular,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "tv" = (
 /obj/item/storage/box/disks_plantgene,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "tJ" = (
 /obj/machinery/chem_master/advanced,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "uM" = (
 /turf/open/indestructible/ground/bl/mud,
-/area/f13/wasteland)
+/area/f13/admeme)
 "uX" = (
 /obj/effect/landmark/start/f13/wastelander,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "vO" = (
-/turf/open/indestructible/ground/bl/outside/grass_standard/meadow,
-/area/f13/village)
+/turf/open/liquid/water/scum_aboveground/north,
+/area/f13/wasteland/bl/lbj)
 "vW" = (
 /obj/structure/mineral_door/transparent,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "wq" = (
 /obj/machinery/hydroponics/constructable{
 	self_sustaining = 1
 	},
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "wI" = (
 /obj/machinery/base_dispenser/enclave,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "wT" = (
 /obj/effect/landmark/start/f13/vaultscientist,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "xb" = (
 /obj/machinery/base_dispenser/ammo,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "xC" = (
 /obj/structure/billboard/vb/lovemybuns,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "yx" = (
 /obj/effect/landmark/start/f13/lbj_foreman,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "yE" = (
 /obj/effect/landmark/start/f13/dfs_grunt,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "yH" = (
 /obj/effect/landmark/start/f13/vaultdoctor,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "zQ" = (
-/obj/item/gun/magic/wand/death/debug,
-/turf/open/indestructible/ground/bl/outside/grass_standard/meadow,
-/area/f13/wasteland)
+/obj/item/melee/bokken/debug,
+/turf/open/indestructible/ground/bl/outside/gravel,
+/area/f13/wasteland/bl/lbj)
 "Ap" = (
 /obj/effect/landmark/start/f13/gmb_militia,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "AL" = (
 /turf/closed/indestructible/f13/matrix,
-/area/f13/wasteland)
+/area/centcom/vip)
+"AX" = (
+/turf/open/liquid/water/scum/west,
+/area/f13/wasteland/bl/lbj)
 "Be" = (
 /obj/machinery/chem_dispenser/fullupgrade,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "BL" = (
-/obj/item/gun/magic/wand/resurrection/debug,
-/turf/open/indestructible/ground/bl/outside/grass_standard/meadow,
-/area/f13/wasteland)
+/turf/open/liquid/water/scum/north,
+/area/f13/wasteland/bl/lbj)
 "Cj" = (
 /obj/effect/landmark/start/f13/dfs_agent,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "CO" = (
 /obj/effect/landmark/latejoin,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "Dg" = (
 /obj/effect/landmark/start/f13/overseer,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "DP" = (
 /obj/effect/landmark/start/f13/vaultrobot,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "Ea" = (
 /obj/machinery/shield_switch,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "EA" = (
 /obj/item/seeds/bl/yarrow,
 /turf/open/indestructible/ground/bl/mud,
-/area/f13/wasteland)
+/area/f13/admeme)
 "ET" = (
 /obj/structure/billboard/vb/vaulttec,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "Fk" = (
 /obj/structure/billboard/vb/oldantucker,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "FE" = (
 /obj/item/gun/energy/arcwelder,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "Gc" = (
-/obj/machinery/autodoc,
-/turf/open/indestructible/ground/bl/outside/grass_standard/meadow,
-/area/f13/wasteland)
+/turf/open/indestructible/necropolis,
+/area/cordon)
+"Gr" = (
+/turf/open/liquid/water/scum_aboveground/west,
+/area/f13/wasteland/bl/lbj)
 "Gw" = (
 /obj/item/storage/toolbox/mechanical,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "GZ" = (
 /obj/structure/billboard/vb/slocumsjoe,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "Hy" = (
 /obj/machinery/light/floor,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "Jb" = (
 /obj/structure/obstacle/barbedwire{
 	dir = 4
 	},
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "Ku" = (
 /obj/effect/landmark/start/f13/gmb_practitioner,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "LL" = (
 /obj/machinery/autolathe/ammo/unlocked_basic,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "Ml" = (
 /obj/structure/billboard/vb/superdupermart,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "MQ" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 8
 	},
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "Nc" = (
 /obj/item/grenade/f13/mine,
 /obj/item/grenade/f13/mine,
@@ -266,114 +274,130 @@
 /obj/item/grenade/f13/mine,
 /obj/item/grenade/f13/mine,
 /obj/item/grenade/f13/mine,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "Nm" = (
 /obj/effect/landmark/start/f13/tavernkeep,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "NA" = (
 /obj/structure/shieldwall/standard_owb/active,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "NP" = (
 /obj/effect/landmark/start/f13/lbj_lumberjack,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "Oe" = (
 /obj/structure/anvil/debugsuper,
 /obj/item/melee/smith/hammer/debug,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "Ov" = (
 /obj/effect/landmark/start/f13/hilltop_leadership,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "OS" = (
 /obj/effect/landmark/start/f13/hilltop_lookout,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "Pa" = (
 /obj/machinery/base_dispenser/food,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "PF" = (
 /obj/effect/landmark/start/f13/dfs_enforcer,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "Qs" = (
 /obj/item/seeds/bl/skullcap,
 /turf/open/indestructible/ground/bl/mud,
-/area/f13/wasteland)
+/area/f13/admeme)
 "Qy" = (
 /obj/effect/landmark/start/f13/vaultdweller,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "QO" = (
 /obj/machinery/plantgenes,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "Rt" = (
 /turf/open/indestructible/ground/bl/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/bl/lbj)
 "RF" = (
-/obj/item/melee/bokken/debug,
-/turf/open/indestructible/ground/bl/outside/grass_standard/meadow,
-/area/f13/wasteland)
+/obj/item/gun/magic/wand/resurrection/debug,
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "RL" = (
 /obj/structure/shieldwall/standard/stun,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "RZ" = (
 /obj/effect/landmark/start/f13/engchief,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "Sy" = (
 /obj/structure/billboard/vb/readmenace,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
+"Tm" = (
+/turf/open/liquid/water/scum/east,
+/area/f13/wasteland/bl/lbj)
 "Tp" = (
 /obj/structure/mortar/fixed,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "TG" = (
 /obj/item/book/granter/trait/holy,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "Vr" = (
 /obj/structure/billboard/vb/ratemed,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "Wb" = (
 /turf/closed/indestructible/f13/matrix,
-/area/f13/village)
+/area/admin)
 "WU" = (
 /obj/machinery/autolathe/ammo,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
+"Xs" = (
+/turf/open/liquid/water/scum_aboveground/east,
+/area/f13/wasteland/bl/lbj)
 "XM" = (
-/turf/open/liquid/water,
-/area/f13/village)
+/turf/open/liquid/water/scum_aboveground/south,
+/area/f13/wasteland/bl/lbj)
 "XV" = (
 /obj/effect/landmark/start/f13/vaultsecurityofficer,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
+"XX" = (
+/turf/open/liquid/water/scum/south,
+/area/f13/wasteland/bl/lbj)
 "Yn" = (
 /obj/machinery/autolathe/hacked,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
+"YF" = (
+/obj/machinery/autodoc,
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
 "YN" = (
 /obj/structure/closet/crate/mortar_shells,
-/turf/open/indestructible,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/bl/outside/stone,
+/area/centcom/vip)
+"Zn" = (
+/turf/open/water/cursed_spring,
+/area/f13/wasteland/bl/lbj)
 "Zp" = (
 /obj/machinery/porta_turret/f13,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 "Zq" = (
 /obj/effect/landmark/start/f13/gmb_walker,
-/turf/open/indestructible,
-/area/f13/village)
+/turf/open/indestructible/sound/pool,
+/area/admin)
 
 (1,1,1) = {"
 Wb
@@ -400,11 +424,11 @@ Wb
 "}
 (2,1,1) = {"
 Wb
-rR
-XM
-XM
-fH
-fH
+Zn
+AX
+Gr
+Gc
+Gc
 Wb
 Zp
 Wb
@@ -423,11 +447,11 @@ Wb
 "}
 (3,1,1) = {"
 Wb
-rR
+BL
 XM
-XM
-fH
-fH
+XX
+Gc
+Gc
 Wb
 fH
 Wb
@@ -446,9 +470,9 @@ Wb
 "}
 (4,1,1) = {"
 Wb
-rR
-XM
-iI
+vO
+Tm
+Xs
 Hy
 iS
 vW
@@ -470,7 +494,7 @@ Wb
 (5,1,1) = {"
 Wb
 rR
-XM
+iI
 iI
 cL
 Gw
@@ -493,7 +517,7 @@ Wb
 (6,1,1) = {"
 Wb
 rR
-XM
+iI
 iI
 WU
 iS
@@ -516,7 +540,7 @@ Wb
 (7,1,1) = {"
 Wb
 rR
-XM
+iI
 iI
 aL
 iS
@@ -539,7 +563,7 @@ Wb
 (8,1,1) = {"
 Wb
 rR
-XM
+iI
 iI
 ju
 iS
@@ -562,7 +586,7 @@ Wb
 (9,1,1) = {"
 Wb
 rR
-XM
+iI
 iI
 LL
 iS
@@ -585,13 +609,13 @@ Wb
 (10,1,1) = {"
 Wb
 rR
-XM
+iI
 iI
 eF
 iS
 Rt
 Rt
-Rt
+zQ
 Jb
 Hy
 Hy
@@ -608,7 +632,7 @@ Wb
 (11,1,1) = {"
 Wb
 rR
-XM
+iI
 iI
 Yn
 iS
@@ -631,7 +655,7 @@ Wb
 (12,1,1) = {"
 Wb
 rR
-XM
+iI
 iI
 cB
 iS
@@ -654,7 +678,7 @@ Wb
 (13,1,1) = {"
 Wb
 rR
-XM
+iI
 iI
 iS
 iS
@@ -677,10 +701,10 @@ Wb
 (14,1,1) = {"
 Wb
 rR
-XM
 iI
-iS
-iS
+iI
+YF
+RF
 Rt
 Rt
 Be
@@ -700,10 +724,10 @@ Wb
 (15,1,1) = {"
 Wb
 rR
-XM
+iI
 iI
 Oe
-iS
+rk
 Rt
 Rt
 tJ
@@ -723,7 +747,7 @@ Wb
 (16,1,1) = {"
 Wb
 rR
-XM
+iI
 iI
 dJ
 dJ
@@ -746,7 +770,7 @@ Wb
 (17,1,1) = {"
 Wb
 rR
-XM
+iI
 iI
 dJ
 dJ
@@ -769,14 +793,14 @@ Wb
 (18,1,1) = {"
 Wb
 rR
-XM
 iI
-Gc
+iI
 dJ
-zQ
-BL
 dJ
-RF
+dJ
+dJ
+dJ
+dJ
 dJ
 dJ
 dJ
@@ -792,7 +816,7 @@ Wb
 (19,1,1) = {"
 Wb
 rR
-XM
+iI
 iI
 aB
 dJ
@@ -815,21 +839,21 @@ Wb
 (20,1,1) = {"
 Wb
 rR
-XM
-XM
-vO
-vO
-vO
-vO
-vO
-vO
-vO
-vO
-vO
-vO
-vO
-vO
-vO
+iI
+iI
+dJ
+dJ
+dJ
+dJ
+dJ
+dJ
+dJ
+dJ
+dJ
+dJ
+dJ
+dJ
+dJ
 fH
 fH
 la
@@ -838,21 +862,21 @@ Wb
 (21,1,1) = {"
 Wb
 rR
-XM
-XM
-vO
-vO
-vO
-vO
-vO
-vO
-vO
-vO
-vO
-vO
-vO
-vO
-vO
+iI
+iI
+dJ
+dJ
+dJ
+dJ
+dJ
+dJ
+dJ
+dJ
+dJ
+dJ
+dJ
+dJ
+dJ
 fH
 fH
 fH

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -499,6 +499,7 @@ SUBSYSTEM_DEF(job)
 		to_chat(M, "<b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")
 		job.radio_help_message(M)
 
+/*
 		to_chat(M, "<FONT color='red'><b>[job.forbids]</b>")
 		to_chat(M, "<FONT color='green'><b>[job.enforces]</b>")
 		if(job.req_admin_notify)
@@ -509,8 +510,10 @@ SUBSYSTEM_DEF(job)
 			to_chat(M, "-------------------------------------------")
 			to_chat(M, "<FONT color='grey'><B>[job.description]</b>")
 			to_chat(M, "-------------------------------------------")
+*/
 
 //		job.job_help_message(M)
+		job.ShowJobStuff(M)
 
 		if(CONFIG_GET(number/minimal_access_threshold))
 			to_chat(M, "<span class='notice'><B>As this station was initially staffed with a [CONFIG_GET(flag/jobs_have_minimal_access) ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] have been added to your ID card.</B></span>")

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -499,6 +499,9 @@
 	states |= icon_states('icons/obj/hydroponics/growing_flowers.dmi')
 	states |= icon_states('icons/obj/hydroponics/growing_mushrooms.dmi')
 	states |= icon_states('icons/obj/hydroponics/growing_vegetables.dmi')
+	states |= icon_states('goon/icons/obj/hydroponics.dmi')
+	states |= icon_states('icons/fallout/flora/flora.dmi')
+	states |= icon_states('modular_badlands/code/modules/environment/icons/bl_flora_bw.dmi')
 	var/list/paths = typesof(/obj/item/seeds) - /obj/item/seeds - typesof(/obj/item/seeds/sample)
 
 	for(var/seedpath in paths)

--- a/code/modules/jobs/bl_job_information.dm
+++ b/code/modules/jobs/bl_job_information.dm
@@ -6,59 +6,61 @@ All related to viewing job specifics easier.
 /*
 The actual information.
 */
-/datum/job/proc/ShowJobStuff(mob/M, rank)
-	var/datum/job/job = SSjob.GetJob(rank)
-
-	var/list/dat = list("<center>")
+/datum/job/proc/ShowJobStuff(mob/M)
+	var/list/dat = list("")
 
 	dat += "<h1>Special Information</h1>"
 
-	dat += "\n<b>- - - - - -</b>"
+	dat += "\n<br><b>- - - - - -</b><br>"
 
-//	rank = job.title
-
-	if(job.forbids)
-		dat += "<FONT color='red'><b>[job.forbids]</b>"
+	if(description)
+		dat += "<b>[description]</b></font>"
 	else
-		dat += "<FONT color='blue'><B>Your job has no forbidden actions. This is a bug. Tell Carl.</b>"
-	if(job.enforces)
-		dat += "<FONT color='green'><b>[job.enforces]</b>"
+		dat += "<FONT color='blue'><b>Your job has no description. This is a bug. Tell Carl.</b></font>"
+
+	dat += "\n<br><b>- - - - - -</b><br>"
+
+	if(forbids)
+		dat += "<FONT color='red'><b>[forbids]</b></font>"
 	else
-		dat += "<FONT color='blue'><B>Your job has no enforced actions. This is a bug. Tell Carl.</b>"
+		dat += "<FONT color='blue'><b>Your job has no forbidden actions. This is a bug. Tell Carl.</b></font>"
 
-	dat += "\n<b>- - - - - -</b>"
+	dat += "\n<br><br>"
 
-	if(job.description)
-		dat += "<FONT color='blue'><B>[job.description]</b>"
+	if(enforces)
+		dat += "<FONT color='green'><b>[enforces]</b></font>"
 	else
-		dat += "<FONT color='blue'><B>Your job has no description. This is a bug. Tell Carl.</b>"
+		dat += "<FONT color='blue'><b>Your job has no enforced actions. This is a bug. Tell Carl.</b></font>"
 
-	dat += "\n<b>- - - - - -</b>"
+	dat += "\n<br><b>- - - - - -</b><br>"
 
-	if(job.req_admin_notify)
-		dat += "<b>You are playing a job that is important for Game Progression. If you have to disconnect immediately, please notify the admins via adminhelp. Otherwise put your locker gear back into the spawn location and head to a matrix.</b>"
+	if(req_admin_notify)
+		dat += "<FONT color='yellow'><b>You are playing a job that is important for Game Progression. \
+		If you have to disconnect immediately, please notify the admins via adminhelp. \
+		Otherwise put your locker gear back into the spawn location and head to a matrix.</b></font>"
 
-		dat += "\n<b>- - - - - -</b>"
+		dat += "\n<br><b>- - - - - -</b><br>"
 
-	if(job.roleplay_exclusive_notify)
-		dat += "<b>You are playing a job that is important for roleplay. In the event of an offensive raid, you are not permitted to participate in an attack. Please refrain from running dungeons when possible.</b>"
+	if(roleplay_exclusive_notify)
+		dat += "<FONT color='yellow'><b>You are playing a job that is important for roleplay. \
+		In the event of an offensive raid, you are not permitted to participate in an attack. \
+		Please refrain from running dungeons when possible.</b></font>"
 
-		dat += "\n<b>- - - - - -</b>"
+		dat += "\n<br><b>- - - - - -</b><br>"
 
-/*
 	var/datum/browser/popup = new(M, "mob_occupation", "Special Information", 640, 400) // Set up the popup browser window
-	popup.set_content(dat)
+	popup.set_content(dat.Join())
 	popup.open()
-*/
 
-	to_chat(usr, "[dat.Join()]")
+
+//	to_chat(M, "[dat.Join()]")
 
 /*
 This is the proc used to display the above.
 */
 /datum/job/proc/job_help_message(mob/M)
-	to_chat(M, "<span class='revenminor'>Your role in the wasteland has additional information attached to it. <a href=?src=[REF(src)];ShowJobStuff=1>(Click Here)</a></span>")
+	to_chat(M, "<span class='boldannounce'>Your role in the wasteland has additional information attached to it. <a href=?src=[REF(src)];ShowJobStuff=1>(Click Here)</a></span>")
 
 /datum/job/Topic(href, href_list)
 	if(href_list["ShowJobStuff"])
-		ShowJobStuff(src)
+		ShowJobStuff(usr)

--- a/code/modules/jobs/job_types/bl_fields.dm
+++ b/code/modules/jobs/job_types/bl_fields.dm
@@ -10,7 +10,7 @@
 	forbids = "Dry Fields Security forbids: <br> \
 				- Provoking wars. You're tough, but not undefeatable. Know what battles you can and can't afford. <br> \
 				- Farming. While not forbidden by any rule or technicality, it is much more cost effective to coerce the locals into giving you what you want. <br> \
-				- Overextend. Never isolate yourself unless you're undercover. A team works better together."
+				- Overextension. Never isolate yourself unless you're undercover. A team works better together."
 
 	enforces = "Dry Fields Security expects: <br> \
 				- Strongarming. Appearing tough and responding to diplomacy with a show of force can work miracles. <br> \

--- a/code/modules/jobs/job_types/bl_town.dm
+++ b/code/modules/jobs/job_types/bl_town.dm
@@ -119,9 +119,9 @@
 	As an Evangelist, you came here on a most devout mission: Teach the local hicks about the love of Christ. \
 	What ended up happening was your swift ascension to a position of leadership in the town thanks to your moderate level of education and accrued goodwill from the locals. \
 	Unlike most other influential men here, you genuinely wish only the best for the settlers."
+	head = /obj/item/clothing/head/helmet/chaplain/witchunter_hat
 	suit = /obj/item/clothing/suit/armored/riot/chaplain/witchhunter
 	uniform = /obj/item/clothing/under/f13/chaplain
-	head = /obj/item/clothing/head/helmet/chaplain/witchunter_hat
 	backpack_contents = list(
 		/obj/item/book/granter/trait/holy =1,
 		/obj/item/storage/book/bible =1,

--- a/code/modules/jobs/job_types/bl_town.dm
+++ b/code/modules/jobs/job_types/bl_town.dm
@@ -62,15 +62,25 @@
 	id = /obj/item/card/id/hilltop_keys
 	backpack = /obj/item/storage/backpack/trekker
 	satchel = /obj/item/storage/backpack/satchel/trekker
-	neck = /obj/item/storage/belt/holster/legholster/dfs
 	ears = /obj/item/radio/headset/headset_town
-	uniform = /obj/item/clothing/under/f13/dfs
-	shoes = /obj/item/clothing/shoes/f13/military
 	r_pocket = /obj/item/flashlight/flare
 // Spare radio for general communication.
 	backpack_contents = list(
 		/obj/item/radio,
 		)
+
+/datum/outfit/job/town/pre_equip(mob/living/carbon/human/H)
+	..()
+	uniform = pick(
+		/obj/item/clothing/under/f13/settler, \
+		/obj/item/clothing/under/f13/lumberjack, \
+		/obj/item/clothing/under/f13/roving)
+	shoes = pick(
+		/obj/item/clothing/shoes/f13/rag, \
+		/obj/item/clothing/shoes/f13/military/explorer, \
+		/obj/item/clothing/shoes/f13/tan, \
+		/obj/item/clothing/shoes/f13/brownie, \
+		/obj/item/clothing/shoes/f13/fancy)
 
 /datum/job/town/f13townleader
 	title = "Hilltop Leadership"
@@ -109,6 +119,9 @@
 	As an Evangelist, you came here on a most devout mission: Teach the local hicks about the love of Christ. \
 	What ended up happening was your swift ascension to a position of leadership in the town thanks to your moderate level of education and accrued goodwill from the locals. \
 	Unlike most other influential men here, you genuinely wish only the best for the settlers."
+	suit = /obj/item/clothing/suit/armored/riot/chaplain/witchhunter
+	uniform = /obj/item/clothing/under/f13/chaplain
+	head = /obj/item/clothing/head/helmet/chaplain/witchunter_hat
 	backpack_contents = list(
 		/obj/item/book/granter/trait/holy =1,
 		/obj/item/storage/book/bible =1,
@@ -242,24 +255,70 @@
 	You are without a doubt the main economic drive of the town. \
 	All thanks to outsider traders who often take a detour to purchase your brew with the hopes of reselling it all over Battleborough and beyond. \
 	No refunds."
+	backpack_contents =  list(/obj/item/cultivator/rake=1,
+							/obj/item/shovel/spade=1,
+		/obj/item/reagent_containers/glass/bucket = 1,
+		/obj/item/storage/bag/plants/portaseeder = 1)
+
+/datum/outfit/job/f13settler/moonshiner/pre_equip(mob/living/carbon/human/H)
+	..()
+	suit = pick(
+		/obj/item/clothing/suit/toggle/labcoat/f13/wanderer,
+		/obj/item/clothing/suit/f13/slavelabor,
+		/obj/item/clothing/suit/f13/vest,
+		/obj/item/clothing/suit/f13/cowboygvest,
+		/obj/item/clothing/suit/f13/westender,
+		/obj/item/clothing/suit/overalls)
+	suit_store = pick(
+		/obj/item/gun/ballistic/revolver/single_shotgun,
+		/obj/item/gun/ballistic/revolver/piperifle)
 
 /datum/outfit/loadout/f13settler/sidewalker
 	name = "Sidewalker"
 	desc = "While a resident of Hilltop, you don't actually have a house here on accounts of being either too poor or too new for one. \
 	This sorry state of events leaves you to take the most disgraceful jobs available around the place or go prospect the many ruins outside of town."
+	shoes = /obj/item/clothing/shoes/f13/rag
+	backpack_contents =  list(/obj/item/cultivator/rake=1,
+							/obj/item/shovel/spade=1)
+
+/datum/outfit/job/f13settler/sidewalker/pre_equip(mob/living/carbon/human/H)
+	..()
+	suit = pick(
+		/obj/item/clothing/suit/toggle/labcoat/f13/wanderer,
+		/obj/item/clothing/suit/f13/slavelabor,
+		/obj/item/clothing/suit/f13/vest,
+		/obj/item/clothing/suit/f13/cowboygvest,
+		/obj/item/clothing/suit/f13/westender,
+		/obj/item/clothing/suit/overalls)
+	suit_store = pick(
+		/obj/item/gun/ballistic/revolver/single_shotgun,
+		/obj/item/gun/ballistic/revolver/piperifle)
 
 /datum/outfit/loadout/f13settler/barber
 	name = "Barber"
 	desc = "You learned to cut hair and do it with unequalled precision. \
 	Sadly due to circumstances only known to you, you had to expand your business practice to surgery and medicine in order to make end's meet. \
 	You likely learned to perform surgery by practising on the desperate."
+	gloves = /obj/item/clothing/gloves/color/latex
+	neck = /obj/item/clothing/neck/stethoscope
+	belt = /obj/item/storage/belt/medical
+	backpack_contents =  list(/obj/item/smelling_salts=1,
+							/obj/item/reagent_containers/glass/bottle/epinephrine=2,
+							/obj/item/storage/firstaid/ancient=1,
+							/obj/item/razor=1)
 
 /datum/outfit/loadout/f13settler/handyman
 	name = "Handyman"
 	desc = "Formally you are equal in status to the Homeowners. The only difference is that you are called to fix just about anything and everything in town. \
 	Walls, floors, sweeping the streets, squeaky bed, unhinged door. If something is broken, you are ready to get paid to fix it."
+	l_hand = /obj/item/storage/toolbox/old
+	backpack_contents = list(/obj/item/book/granter/trait/techno=1)
 
 /datum/outfit/loadout/f13settler/homeowner
 	name = "Homeowner"
 	desc = "You lucked out. You actually own a place to sleep in at night. \
 	And this is because you are either really good at what you do, or because you are involved in the local Moonshining business as a farmer."
+	backpack_contents = list(
+		/obj/item/stack/sheet/metal/fifty = 1,
+		/obj/item/stack/sheet/mineral/wood/fifty = 1,
+		/obj/item/toy/crayon/spraycan = 1)

--- a/code/modules/jobs/job_types/bl_vault.dm
+++ b/code/modules/jobs/job_types/bl_vault.dm
@@ -357,6 +357,9 @@ Vault Dweller
 	department_head = list("Overseer")
 	total_positions = -1
 	spawn_positions = -1
+	description = "You're one of many within this old-world vault. Bankrolled by your ancestors ages ago, it's here that their lineage continues. \
+	By all accounts, it's a well lit, comfy hole in the earth, with a well established compound on the surface for trading. \
+	Try to listen to the Overseer, lest you wish to fall on their bad side."
 	exp_requirements = 60
 	exp_type = EXP_TYPE_FALLOUT
 
@@ -377,7 +380,8 @@ Vault Dweller
 	spawn_positions = 1
 	description = "You are a Robotic unit assigned to Vault Fifty-Eight. \
 	As a Robot for Vault-Tec, you're bound to the orders of the assigned Overseer, Security and Dwellers, in that order for priority. \
-	Should the Overseer or Security declare something, you must follow it."
+	Should the Overseer or Security declare something, you must follow it. You may ignore the general population otherwise, \
+	so long as it doesn't conflict with your laws."
 	exp_requirements = 60
 
 /datum/job/vault/f13borg/equip(mob/living/carbon/human/H, visualsOnly = FALSE, announce = TRUE, latejoin = FALSE, datum/outfit/outfit_override = null, client/preference_source)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -398,7 +398,7 @@
 	name = "Imitation Stimpak Fluid"
 	id = /datum/reagent/medicine/stimpakimitation
 	results = list(/datum/reagent/medicine/stimpakimitation = 2)
-	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/consumable/mutjuice = 1)
+	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/consumable/yarrowpulp = 1)
 	OptimalTempMin 		= 500 // Lower area of bell curve for determining heat based rate reactions
 	OptimalTempMax		= 650 // Upper end for above
 	ExplodeTemp			= 9999 //Temperature at which reaction explodes

--- a/code/modules/unit_tests/plantgrowth_tests.dm
+++ b/code/modules/unit_tests/plantgrowth_tests.dm
@@ -10,6 +10,7 @@
 	states |= icon_states('icons/obj/hydroponics/growing_vegetables.dmi')
 	states |= icon_states('goon/icons/obj/hydroponics.dmi')
 	states |= icon_states('icons/fallout/flora/flora.dmi')
+	states |= icon_states('modular_badlands/code/modules/environment/icons/bl_flora_bw.dmi')
 	var/list/paths = subtypesof(/obj/item/seeds) - /obj/item/seeds - typesof(/obj/item/seeds/sample) - /obj/item/seeds/lavaland
 
 	for(var/seedpath in paths)

--- a/modular_badlands/code/modules/environment/flora.dm
+++ b/modular_badlands/code/modules/environment/flora.dm
@@ -46,6 +46,10 @@
 	icon_state = "ERROR"
 	species = "error_or_something_lol"
 	plantname = "Error Bush"
+	icon_grow = "licorice-grow"//for checks
+	icon_dead = "licorice-dead"//for checks
+	icon_harvest = "licorice-harvest"//for checks
+	growing_icon = 'modular_badlands/code/modules/environment/icons/bl_flora_bw.dmi'
 	product = /obj/item/reagent_containers/food/snacks/grown/bl
 	lifespan = 100
 	endurance = 30
@@ -55,7 +59,6 @@
 	potency = 30
 	growthstages = 1
 	rarity = 20
-	growing_icon = 'modular_badlands/code/modules/environment/icons/bl_flora_bw.dmi'
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 
 /obj/item/seeds/bl/licorice
@@ -64,6 +67,9 @@
 	icon_state = "seed"
 	species = "licorice"
 	plantname = "licorice bush"
+	icon_grow = "licorice-grow"
+	icon_dead = "licorice-dead"
+	icon_harvest = "licorice-harvest"
 	product = /obj/item/reagent_containers/food/snacks/grown/bl/licorice
 	lifespan = 100
 	endurance = 30
@@ -81,6 +87,9 @@
 	icon_state = "seed"
 	species = "milkweed"
 	plantname = "milkweed bush"
+	icon_grow = "milkweed-grow"
+	icon_dead = "milkweed-dead"
+	icon_harvest = "milkweed-harvest"
 	product = /obj/item/reagent_containers/food/snacks/grown/bl/milkweed
 	lifespan = 100
 	endurance = 30
@@ -98,6 +107,9 @@
 	icon_state = "seed"
 	species = "yarrow"
 	plantname = "yarrow bush"
+	icon_grow = "yarrow-grow"
+	icon_dead = "yarrow-dead"
+	icon_harvest = "yarrow-harvest"
 	product = /obj/item/reagent_containers/food/snacks/grown/bl/yarrow
 	lifespan = 100
 	endurance = 30
@@ -115,6 +127,9 @@
 	icon_state = "seed"
 	species = "skullcap"
 	plantname = "skullcap bush"
+	icon_grow = "skullcap-grow"
+	icon_dead = "skullcap-dead"
+	icon_harvest = "skullcap-harvest"
 	product = /obj/item/reagent_containers/food/snacks/grown/bl/skullcap
 	lifespan = 100
 	endurance = 30


### PR DESCRIPTION
Fixes for jobs/bl_job_information.dm courtesy of Phaze.
Need to finish Hilltop loadouts at some point. Very tedious for my small brain.
Some additions and changes as well to the debug map.
- - -
Other:
- Imitation stims now use Yarrow Pulp.
- Tests for plants updated, so hopefully we'll stop seeing errors. We really should make this test not garbage, though. Perhaps pull from TG?